### PR TITLE
Fix Footer issue when no articles are saved to savedArticles on render

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -1,7 +1,7 @@
 /* APP COMPONENT */
 
 
-[data-test="App"] {
+.App {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -359,6 +359,31 @@
   margin: 100px 13%;  /* make % smaller the wider you want the container. 100px top to fall below the header, 100 from bottom to be able to see the ellipsis dropdown on bottom article */
 }
 
+.article_saved-articles-none-saved {
+  /* border: 1px solid black; */
+  width: 100%; 
+  height: calc(100vh - 220px);  /* 100vh take the footer, header, and margins/padding inbetween - didnt actually work out just kept doing trial and error and saw how it changed on the page */ 
+  display: flex;
+  flex-direction: column; 
+  /* align-items: center; */
+  justify-content: center;
+}
+
+.article_saved-articles-none-saved * {
+  text-align: center;
+  margin: 10px 0px;
+}
+
+.article_saved-articles {
+  width: 100%; 
+  height: calc(100vh - 220px);  /* 100vh take the footer, header, and margins/padding inbetween - didnt actually work out just kept doing trial and error and saw how it changed on the page */ 
+}
+
+.article_saved-articles-2plus {
+  width: 100%;
+  height: 100%;
+}
+
 .article_outer-div {
   position: relative;
 }
@@ -366,6 +391,18 @@
 .article_outer-container {
   /* border: red 1px solid !important; */
   width: 100%;
+  display: flex;
+  padding: 5px 0px;
+  margin-bottom: 20px;
+  background-color: #FFFFFF;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.article_outer-container-saved-on-render {
+  /* border: red 1px solid !important; */
+  width: 100%;
+  height: 100%;
   display: flex;
   padding: 5px 0px;
   margin-bottom: 20px;

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -13,9 +13,10 @@ import Articles from '../components/Articles';
 
 function App() {
   // <script src="jquery-2.1.4.js"></script>
+  
   return (
     <Router>
-      <div data-test="App">
+      <div className="App">
         {/* <div className="App_loading-wrapper">
           <span className="loader"><span className="loader-inner"></span></span>
         </div> */}
@@ -40,7 +41,7 @@ function App() {
         
         {/* {need to find a way to load this in on window load - maybe in article slice will pop as no display for now but thats not currently pushed and merged to master yet so will do that later} */}
       </div>
-    </Router>
+    </Router> 
   );
 }
 

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -9,6 +9,7 @@ import Ellipsis from './Ellipsis';
 import ReportModal from './ReportModal';
 
 const Article = ({ id, score, author, created, title, numComments, saved, thumbnail, articles, articleType, scoredUp, scoredDown, hidden, reported }) => {
+
   return (
     <div className={hidden ? "article_outer-container-hide" : "article_outer-container"} id={id}>
       <Score id={id} articleType={articleType} score={score} currentArticles={articles} scoredUp={scoredUp} scoredDown={scoredDown} />

--- a/src/components/Articles.js
+++ b/src/components/Articles.js
@@ -98,9 +98,13 @@ const Articles = () => {
       {dataLoading ? 
         <div className="App_loading-wrapper">
           <span className="loader"><span className="loader-inner"></span></span>
-        </div> : !dataLoading && articles !== savedArticles ? articles.map(article => ( 
-        <Article key={article.id} id={article.id} score={article.score} author={article.author} created={article.created} title={article.title} numComments={article.numComments} saved={article.saved} thumbnail={article.thumbnail} articles={articles} articleType={article.articleType} scoredUp={article.scoredUp} scoredDown={article.scoredDown} hidden={article.hidden} reported={article.reported} /> 
-      )) : <SavedArticles />}
+        </div> : !dataLoading && articles !== savedArticles ? 
+          articles.map(article => ( 
+            // <div className="article_container">
+              <Article key={article.id} id={article.id} score={article.score} author={article.author} created={article.created} title={article.title} numComments={article.numComments} saved={article.saved} thumbnail={article.thumbnail} articles={articles} articleType={article.articleType} scoredUp={article.scoredUp} scoredDown={article.scoredDown} hidden={article.hidden} reported={article.reported} /> 
+            // </div>
+          )) 
+      : <SavedArticles />}
     </div>
   )
 }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,6 +1,9 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 const Footer = () => {
+  const location = useLocation(); 
+  
   return (
     <div className="footer">
       <h1>Joe Elliott</h1><p>&copy;</p>

--- a/src/components/SavedArticles.js
+++ b/src/components/SavedArticles.js
@@ -11,7 +11,7 @@ const SavedArticles = () => {
   const initialState = useSelector(selectInitialState); 
   const savedArticles = useSelector(selectSavedArticle);
 
-  console.log(initialState);
+  // console.log(initialState);
 
 
   useEffect(() => {
@@ -33,13 +33,17 @@ const SavedArticles = () => {
   }, [sideNavState.eyeClicked]); // only executes on eyeClick state change (clicking the eye)
 
   return (
-    <div>
-      {savedArticles.length > 0 ? savedArticles.map(article => ( 
-        <Article key={article.id} id={article.id} score={article.score} author={article.author} created={article.created} title={article.title} numComments={article.numComments} saved={article.saved} thumbnail={article.thumbnail} articleType={article.articleType} scoredUp={article.scoredUp} scoredDown={article.scoredDown} articles={savedArticles} hidden={article.hidden} reported={article.reported} /> 
-      )) : 
-      <div>
+    <div className={savedArticles.length < 3 ? "article_saved-articles" : "article_saved-articles-2plus"}> 
+      {savedArticles.length > 0 ? savedArticles.map(article => (
+        
+          <Article key={article.id} id={article.id} score={article.score} author={article.author} created={article.created} title={article.title} numComments={article.numComments} saved={article.saved} thumbnail={article.thumbnail} articleType={article.articleType} scoredUp={article.scoredUp} scoredDown={article.scoredDown} articles={savedArticles} hidden={article.hidden} reported={article.reported} /> 
+      ))
+      : 
+
+      // THIS IS WHERE TO CHANGE STYLE WHEN NO POSTS SAVED IN SAVEDARTICLES (BELOW)
+      <div className="article_saved-articles-none-saved">
         <h1>You currently have no saved posts.</h1>
-        <p>Click save on your favorite posts and see them all together here.</p>
+        <p>Click <strong>save</strong> on your favorite posts and see them all together here.</p>
       </div>}        
     </div>
   )


### PR DESCRIPTION
- Footer now sits at the bottom of the UI on the saved articles page on first render when no articles have been saved. 
- Style resets to match those of other Link pages execute when a third article is added to savedArticles and therefore fills the page. 